### PR TITLE
Fix images expiring, allow reels/videos & save permalink in database

### DIFF
--- a/admin/src/pages/Settings/index.js
+++ b/admin/src/pages/Settings/index.js
@@ -7,6 +7,7 @@ import { ContentLayout, HeaderLayout } from '@strapi/design-system/Layout';
 import { Link } from '@strapi/design-system/Link';
 import { Stack } from '@strapi/design-system/Stack';
 import { TextInput } from '@strapi/design-system/TextInput';
+import { Checkbox } from '@strapi/design-system/Checkbox';
 import { ToggleInput } from '@strapi/design-system/ToggleInput';
 import { Tooltip } from '@strapi/design-system/Tooltip';
 import { Typography } from '@strapi/design-system/Typography';
@@ -29,6 +30,7 @@ const Settings = () => {
   const [isDevAlertShow, setDevAlertShow] = useState(true);
   const [instagram_app_id, setInstagramAppId] = useState();
   const [instagram_app_secret, setInstagramAppSecret] = useState();
+  const [instagram_allow_videos, setInstagramAllowVideos] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
 
   useEffect(() => {
@@ -42,6 +44,7 @@ const Settings = () => {
       setIsLoading(false);
     });
   };
+
   const checkAuthResponse = async () => {
     if (window.location.pathname.split('/').pop() == 'auth') {
       const urlSearchParameters = new URLSearchParams(window.location.search);
@@ -81,10 +84,12 @@ const Settings = () => {
   useEffect(() => {
     setInstagramAppId(settings.instagram_app_id);
     setInstagramAppSecret(settings.instagram_app_secret);
+    setInstagramAllowVideos(settings.instagram_allow_videos);
   }, [settings]);
 
   const handleImageDownload = async () => {
     setIsDownloading(true);
+
     instagramBasicApiRequest
       .downloadImages({
         force: true,
@@ -101,7 +106,8 @@ const Settings = () => {
       instagram_app_id != '' &&
       instagram_app_secret != '' &&
       instagram_app_id == settings.instagram_app_id &&
-      instagram_app_secret == settings.instagram_app_secret
+      instagram_app_secret == settings.instagram_app_secret &&
+      instagram_allow_videos == settings.instagram_allow_videos
     );
   };
 
@@ -121,6 +127,7 @@ const Settings = () => {
       instagram_app_id: instagram_app_id,
       instagram_app_secret: instagram_app_secret,
       state: generateAuthState(),
+      instagram_allow_videos: instagram_allow_videos || false
     });
 
     setSettings(res.data);
@@ -239,6 +246,15 @@ const Settings = () => {
                   >
                     Download Images
                   </Button>
+                </GridItem>
+                <GridItem col={12} s={12}>
+                  <Checkbox
+                    value={instagram_allow_videos}
+                    onChange={() => setInstagramAllowVideos(!instagram_allow_videos)}
+                    hint="This will allow you to save videos (including reels) with their thumbnails into the database."
+                  >
+                    Include videos in download
+                  </Checkbox>
                 </GridItem>
                 <GridItem col={12} s={12}>
                   <TextInput

--- a/server/content-types/image/schema.json
+++ b/server/content-types/image/schema.json
@@ -36,7 +36,7 @@
       "type": "datetime"
     },
     "caption": {
-      "type": "text"
+      "type": "text",
       "maxLength": 9999,
       "column": {
         "type": "text"

--- a/server/content-types/image/schema.json
+++ b/server/content-types/image/schema.json
@@ -28,14 +28,23 @@
     "originalUrl": {
       "type": "text"
     },
-    "mediaId": {
-      "type": "text"
-    },
     "timestamp": {
       "type": "datetime"
     },
     "caption": {
       "type": "string"
+    },
+    "permalink": {
+      "type": "text"
+    },
+    "mediaId": {
+      "type": "string"
+    },
+    "mediaType": {
+      "type": "string"
+    },
+    "thumbnailUrl": {
+      "type": "text"
     }
   }
 }

--- a/server/content-types/image/schema.json
+++ b/server/content-types/image/schema.json
@@ -29,7 +29,7 @@
       "type": "text"
     },
     "mediaId": {
-      "type": "integer"
+      "type": "text"
     },
     "timestamp": {
       "type": "datetime"

--- a/server/controllers/instagramBasicApi.js
+++ b/server/controllers/instagramBasicApi.js
@@ -13,7 +13,10 @@ module.exports = ({ strapi }) => ({
     }
   },
   async getImages(ctx) {
-    const { body } = ctx.request;
+    const { body, query, method } = ctx.request;
+
+    const params = method === 'GET' ? query : body;
+
     try {
       // Token refresh if necessary
       ctx.body = await strapi
@@ -29,7 +32,7 @@ module.exports = ({ strapi }) => ({
       ctx.body = await strapi
         .plugin('instagram')
         .service('instaimage')
-        .find(body);
+        .find(params);
     } catch (err) {
       ctx.throw(500, err);
     }

--- a/server/services/instagramBasicApi.js
+++ b/server/services/instagramBasicApi.js
@@ -23,7 +23,7 @@ module.exports = ({ strapi }) => ({
     album.data.forEach((element) => {
       if (element.media_type == 'IMAGE') {
         media.push({
-          parent: parent.id,
+          mediaId: parent.id,
           id: element.id,
           url: element.media_url,
           timestamp: element.timestamp,
@@ -69,6 +69,7 @@ module.exports = ({ strapi }) => ({
     for (let element of instagramMedia.data) {
       if (element.media_type == 'IMAGE') {
         images.push({
+          mediaId: element.id,
           id: element.id,
           url: element.media_url,
           timestamp: element.timestamp,
@@ -111,6 +112,7 @@ module.exports = ({ strapi }) => ({
         const entry = await strapi.db.query(dbImageName).create({
           data: {
             instagramId: image.id,
+            mediaId: image.mediaId,
             originalUrl: image.url,
             timestamp: image.timestamp,
             caption: image.caption,

--- a/server/services/instagramBasicApi.js
+++ b/server/services/instagramBasicApi.js
@@ -21,7 +21,7 @@ module.exports = ({ strapi }) => ({
     );
     const media = [];
     album.data.forEach((element) => {
-      if (element.media_type === 'IMAGE' || element.media_type === 'VIDEO') {
+      if (element.media_type === 'IMAGE' || (element.media_type === 'VIDEO' && settings.instagram_allow_videos)) {
         media.push({
           mediaId: parent.id,
           id: element.id,
@@ -68,7 +68,7 @@ module.exports = ({ strapi }) => ({
     );
     let images = [];
     for (let element of instagramMedia.data) {
-      if (element.media_type === 'IMAGE' || element.media_type === 'VIDEO') {
+      if (element.media_type === 'IMAGE' || (element.media_type === 'VIDEO' && settings.instagram_allow_videos)) {
         images.push({
           mediaId: element.id,
           id: element.id,

--- a/server/services/instagramBasicApi.js
+++ b/server/services/instagramBasicApi.js
@@ -12,6 +12,8 @@ const dbImageName = 'plugin::instagram.instaimage';
 
 module.exports = ({ strapi }) => ({
   async downloadAlbum(parent, token) {
+    const settings = await getPluginSettings();
+
     const album = await fetchInstagram.callInstagramGraph(
       `/${parent.id}/children`,
       {

--- a/server/services/instagramBasicApi.js
+++ b/server/services/instagramBasicApi.js
@@ -5,7 +5,7 @@ const { getPluginSettings, setPluginSettings } = instagramSettings;
 const fetchInstagram = require('../utils/fetchInstagram');
 const dateUtils = require('../utils/dateUtils');
 
-const album_fields = 'id,media_type,media_url,thumbnail_url,username,timestamp';
+const album_fields = 'id,media_type,media_url,thumbnail_url,username,timestamp,permalink';
 const media_fields = `${album_fields},caption`;
 
 const dbImageName = 'plugin::instagram.instaimage';
@@ -29,6 +29,7 @@ module.exports = ({ strapi }) => ({
           timestamp: element.timestamp,
           caption: parent.caption,
           media_type: element.media_type,
+          permalink: element.permalink
         });
       }
     });
@@ -73,6 +74,7 @@ module.exports = ({ strapi }) => ({
           timestamp: element.timestamp,
           caption: element.caption,
           media_type: element.media_type,
+          permalink: element.permalink
         });
       } else if (element.media_type == 'CAROUSEL_ALBUM') {
         const album = await this.downloadAlbum(element, token);
@@ -102,6 +104,7 @@ module.exports = ({ strapi }) => ({
             timestamp: image.timestamp,
             caption: image.caption,
             publishedAt: new Date(),
+            permalink: image.permalink
           },
         });
       }

--- a/server/services/instagramBasicApi.js
+++ b/server/services/instagramBasicApi.js
@@ -21,15 +21,16 @@ module.exports = ({ strapi }) => ({
     );
     const media = [];
     album.data.forEach((element) => {
-      if (element.media_type == 'IMAGE') {
+      if (element.media_type === 'IMAGE' || element.media_type === 'VIDEO') {
         media.push({
           mediaId: parent.id,
           id: element.id,
           url: element.media_url,
           timestamp: element.timestamp,
           caption: parent.caption,
-          media_type: element.media_type,
-          permalink: element.permalink
+          mediaType: element.media_type,
+          permalink: element.permalink,
+          thumbnailUrl: element.media_type === 'VIDEO' ? element.thumbnail_url : null
         });
       }
     });
@@ -67,17 +68,18 @@ module.exports = ({ strapi }) => ({
     );
     let images = [];
     for (let element of instagramMedia.data) {
-      if (element.media_type == 'IMAGE') {
+      if (element.media_type === 'IMAGE' || element.media_type === 'VIDEO') {
         images.push({
           mediaId: element.id,
           id: element.id,
           url: element.media_url,
           timestamp: element.timestamp,
           caption: element.caption,
-          media_type: element.media_type,
-          permalink: element.permalink
+          mediaType: element.media_type,
+          permalink: element.permalink,
+          thumbnailUrl: element.media_type === 'VIDEO' ? element.thumbnail_url : null
         });
-      } else if (element.media_type == 'CAROUSEL_ALBUM') {
+      } else if (element.media_type === 'CAROUSEL_ALBUM') {
         const album = await this.downloadAlbum(element, token);
         images = images.concat(album);
       }
@@ -105,7 +107,8 @@ module.exports = ({ strapi }) => ({
         const entry = await strapi.db.query(dbImageName).update({
           where: { instagramId: image.id },
           data: {
-            originalUrl: image.url
+            originalUrl: image.url,
+            thumbnailUrl: image.thumbnailUrl
           }
         });
       } else {
@@ -117,7 +120,9 @@ module.exports = ({ strapi }) => ({
             timestamp: image.timestamp,
             caption: image.caption,
             publishedAt: new Date(),
-            permalink: image.permalink
+            permalink: image.permalink,
+            thumbnailUrl: image.thumbnailUrl,
+            mediaType: image.mediaType
           },
         });
       }

--- a/server/services/instagramBasicApi.js
+++ b/server/services/instagramBasicApi.js
@@ -96,7 +96,18 @@ module.exports = ({ strapi }) => ({
 
   async insertImagesToDatabase(images) {
     for (let image of images) {
-      if (!(await this.isImageExists(image))) {
+      const imageExists = await this.isImageExists(image);
+
+      if (imageExists) {
+        // Update image url if already exists in order to prevent
+        // url to be invalid after a week
+        const entry = await strapi.db.query(dbImageName).update({
+          where: { instagramId: image.id },
+          data: {
+            originalUrl: image.url
+          }
+        });
+      } else {
         const entry = await strapi.db.query(dbImageName).create({
           data: {
             instagramId: image.id,


### PR DESCRIPTION
A few items were missing or were causing errors in my production environment. These were:

- Reels did not show up, we wanted to use the thumbnails of these in the feed
- Permalinks (links to the actual post on Instagram) were missing
- Most importantly, the image links expire after 1 week as these were not updated if a post already existed in the database

These commits should fix these issues. Furthermore, It is improved with extra data now being saved in the database that might be useful for broader use cases.