### PR TITLE
Query parameters were ignored.

### DIFF
--- a/server/controllers/instagramBasicApi.js
+++ b/server/controllers/instagramBasicApi.js
@@ -13,7 +13,7 @@ module.exports = ({ strapi }) => ({
     }
   },
   async getImages(ctx) {
-    const { body } = ctx.request;
+    const { query } = ctx.request;
     try {
       // Token refresh if necessary
       ctx.body = await strapi
@@ -29,7 +29,7 @@ module.exports = ({ strapi }) => ({
       ctx.body = await strapi
         .plugin('instagram')
         .service('instaimage')
-        .find(body);
+        .find(query);
     } catch (err) {
       ctx.throw(500, err);
     }


### PR DESCRIPTION
I attempted to utilize the strapi sort and pagination query parameters, but they did not function as expected. However, after trying an alternative approach, it seems to be working now.

_api/instagram/images?pagination[page]=1&pagination[pageSize]=1_ behaved as _api/instagram/images_
